### PR TITLE
sed on mac needs -e

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -18,4 +18,6 @@ post_install_actions:
   - |
     #ddev-description: Change the redis dump filename
     #
-    sed -i -e "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots.conf
+    # sed -i -e "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots.conf
+    # blind test
+    docker run -i --rm ddev/ddev-utilities sed -i -e "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots.conf

--- a/install.yaml
+++ b/install.yaml
@@ -17,7 +17,4 @@ project_files:
 post_install_actions:
   - |
     #ddev-description: Change the redis dump filename
-    #
-    # sed -i -e "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots.conf
-    # blind test
-    docker run -i --rm ddev/ddev-utilities sed -i -e "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots.conf
+    docker run -e DDEV_SITENAME -v "$(pwd)"/redis:/redis -i --rm ddev/ddev-utilities bash -c "sed -i 's/REPLACE_ME/$DDEV_SITENAME/g' /redis/snapshots.conf"

--- a/install.yaml
+++ b/install.yaml
@@ -18,4 +18,4 @@ post_install_actions:
   - |
     #ddev-description: Change the redis dump filename
     #
-    sed -i "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots.conf
+    sed -i -e "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots.conf

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -84,7 +84,7 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd "$TEST_DIR" || ( printf "unable to cd to "$TEST_DIR"\n" && exit 1 )
-  echo "# ddev get oblakstudio/ddev-redis with project "$PROJECT" in "$TEST_DIR"" >&3
-  health_checks "oblakstudio/ddev-redis-7"
+  echo "# ddev get ddev/ddev-redis with project "$PROJECT" in "$TEST_DIR"" >&3
+  health_checks "ddev/ddev-redis-7"
 }
 


### PR DESCRIPTION
## The Issue
See Issue #24

sed on macos needs "-e" before the script

## How This PR Solves The Issue

changes 

sed -i  "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots

to 

sed -i -e "s/REPLACE_ME/${DDEV_SITENAME}/g" redis/snapshots

## Manual Testing Instructions

on mac 

cd into ddev project
ddev get ddev-redis-7

