### PR TITLE
fix: make the add-on work with DDEV v1.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@
 
 This repository provides [Redis 7](https://redis.com) container for [DDEV](https://ddev.readthedocs.io/).
 
-It is based on [redis:7-alpine](https://hub.docker.com/_/redis/tags?page=1&name=7) docker image and [DDEV custom compose files](https://ddev.readthedocs.io/en/stable/users/extend/custom-compose-files/)
+It is based on [redis:7.2-alpine](https://hub.docker.com/_/redis/tags?page=1&name=7) docker image and [DDEV custom compose files](https://ddev.readthedocs.io/en/stable/users/extend/custom-compose-files/)
 
-## Comparison to **v6** (`ddev/ddev-redis`)
+## Comparison to **v6** ([`ddev/ddev-redis`](https://github.com/ddev/ddev-redis))
 
-There are a lot of differences between [v6](https://github.com/ddev/ddev-redis) addon and this one
+There are a lot of differences between v6 addon and this one
 
 | Feature           | ddev/ddev-redis  | ddev/ddev-redis-7 |
 | ----------------- | ---------------- | ----------------- |
 | Maximum Memory    | Unlimited        | 512Mb             |
-| Persistence       | No               | **Yes**           |
-| Redis Version     | 6.2.5            | 7.2.1             |
+| Persistence       | Optional         | **Yes**           |
+| Redis Version     | 6.x.y            | 7.2.x             |
 | Image Size        | ~40Mb            | ~11Mb             |
-| Anonymous Volumes | On every restart | **NO**            |
+| Anonymous Volumes | No               | No                |
 | Optimized config  | No               | **Yes**           |
 
 ### Anonymous volumes - Wait, what?

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -13,6 +13,7 @@ services:
     command: /etc/redis/conf/redis.conf
     volumes:
       - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
       - "./redis:/etc/redis/conf"
       - "redis:/data"
     expose:

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -23,10 +23,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2"
+          cpus: "2.5"
           memory: "768M"
         reservations:
-          cpus: "1"
+          cpus: "1.5"
           memory: "512M"
     restart: "no"
     labels:


### PR DESCRIPTION
## The Issue

- #27

## How This PR Solves The Issue

- Service should mount ddev-global-cache (see [this PR](https://github.com/ddev/ddev-redis/pull/22))
- Update README.md (after [changes](https://github.com/ddev/ddev-redis/pull/19) in `ddev/ddev-redis`)
- Fix an error from docker-compose in DDEV v1.23.0 (use `float` as a workaround):

```
* error decoding 'services[redis].deploy.resources.limits.cpus': unexpected value type int for cpus
```

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

