### PR TITLE
fix: display status badge for default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # ddev-redis-7 - Redis 7 container for DDEV
 
 [![GitHub release (with filter)](https://img.shields.io/github/v/release/ddev/ddev-redis-7)](https://github.com/ddev/ddev-redis-7/releases)
-[![Tests](https://github.com/ddev/ddev-redis-7/actions/workflows/cron_tests.yml/badge.svg)](https://github.com/ddev/ddev-redis-7/actions/workflows/cron_tests.yml)
+[![tests](https://github.com/ddev/ddev-redis-7/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-redis-7/actions/workflows/tests.yml)
 ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 </div>
@@ -53,14 +53,14 @@ Then restart your project
 ddev restart
 ```
 
-> [!IMPORTANT]  
-> Authentication is setup by default, and the password is `redis`.  
-> If needed, you can auth with a username and password.  
+> [!IMPORTANT]
+> Authentication is setup by default, and the password is `redis`.
+> If needed, you can auth with a username and password.
 > Username is `redis` as well.
 
 ## Configuration
 
-Redis configuration files are split in the `.ddev/redis/conf` folder, you can modify them as you wish.  
+Redis configuration files are split in the `.ddev/redis/conf` folder, you can modify them as you wish.
 Otherwise, plugin just works out of the box.
 
 ## Commands
@@ -74,5 +74,5 @@ Addon exposes the following commands
 | `redis-flush`     | `ddev redis-flush` | Clears all the Redis Databases     |
 ___
 
-**Based on the original [ddev-contrib recipe](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/mongodb)**  
+**Based on the original [ddev-contrib recipe](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/mongodb)**
 **Developed and maintained by [Oblak Studio](https://github.com/oblakstudio)**


### PR DESCRIPTION
## The Issue

The "test" status badge displays as a broken link.

![image](https://github.com/user-attachments/assets/cc1e29c0-a609-4245-8615-9f8301e8bb3e)

(screenshot of https://github.com/ddev/ddev-redis-7)

## How This PR Solves The Issue

This PR updates the badge URL to correctly display. 

![image](https://github.com/user-attachments/assets/d9436ecb-c423-483f-a204-1393aecc3a49)

(screenshot was taken from VSCode markdown viewer)


## Manual Testing Instructions


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
